### PR TITLE
added github action to generate docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Generate documentation
+on:
+  push:
+   branches: [ "main" ]
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  gen_html_documentaiton:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v2 # Required to mount the Github Workspace to a volume 
+      - name: protoc-gen-doc 
+        uses: addnab/docker-run-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: gcr.io
+          image: pseudomuto/protoc-gen-doc
+          options: -v ${{ github.workspace }}:/protos -v ${{ github.workspace }}/docs:/out
+          run: |
+            echo "Running generation"
+            "./entrypoint.sh"
+            echo "Finished generation"              
+      - name: Upload artifact for pages
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: ${{ github.workspace }}/docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2          


### PR DESCRIPTION
Hi,

I added a github action that generates a documentation (https://github.com/pseudomuto/protoc-gen-doc) for the protobuf messages and publishes it to github pages. I would like to link that then in the rcll-get-started repository.

For my fork the site looks like the following: https://pkohout.github.io/rcll-protobuf-msgs/