### PR TITLE
add qol info

### DIFF
--- a/MachineInfo.proto
+++ b/MachineInfo.proto
@@ -92,6 +92,9 @@ message Machine {
   optional string type = 2;
   optional string state = 3;
   optional Team team_color = 10;
+  // tag information
+  optional uint32 input_tag = 5;
+  optional uint32 output_tag = 6;
 
   // Current state of the lights
   repeated LightSpec lights = 7;

--- a/VersionInfo.proto
+++ b/VersionInfo.proto
@@ -41,6 +41,29 @@ package llsf_msgs;
 option java_package = "org.robocup_logistics.llsf_msgs";
 option java_outer_classname = "VersionProtos";
 
+message ConfigValue {
+  enum CompType {
+    COMP_ID = 2000;
+    MSG_TYPE = 6;
+  }
+  enum ValueType {
+    STRING = 0;
+    BOOLEAN = 1;
+    FLOAT = 2;
+    INTEGER = 3;
+  }
+
+  // The name of the config
+  required string name = 1;
+  // One of STRING BOOLEAN INTEGER FLOAT
+  required ValueType type = 2;
+  // The possible values, exactly one of those is
+  optional string string_value  = 5;
+  optional bool boolean_value  = 6;
+  optional uint32 integer_value  = 7;
+  optional float float_value  = 8;
+}
+
 message VersionInfo {
   enum CompType {
     COMP_ID = 2000;
@@ -51,4 +74,7 @@ message VersionInfo {
   required uint32 version_minor = 2;
   required uint32 version_micro = 3;
   required string version_string = 4;
+
+  // Various configuration values that shape the behavior of the refbox
+  repeated ConfigValue configuration = 10;
 }


### PR DESCRIPTION
This PR adds fields in MachineInfo to describe tag ids associated with the machine and also extends VersionInfo through a list of configurations that shape the behavior of the refbox, e.g., field layout parameters, challenge information.